### PR TITLE
Increase timeouts as temporary fix

### DIFF
--- a/src/types/wait.ts
+++ b/src/types/wait.ts
@@ -5,7 +5,7 @@ export function waitForHealthCheck({
     command,
     container,
     expectedResult,
-    timeoutMS = 60000,
+    timeoutMS = 120000,
     waitBeforeStart = 1000
 }: {
     command: string;

--- a/test/cases/bootstrapping.test.ts
+++ b/test/cases/bootstrapping.test.ts
@@ -19,7 +19,7 @@ describe('bootstrapping', () => {
             env = await setupTestEnvironment(basic as SetupJson);
             await verifyEnv(env);
         },
-        Timeouts.TEST
+        Timeouts.SETUP
     );
 
     it(
@@ -28,6 +28,6 @@ describe('bootstrapping', () => {
             env = await setupTestEnvironment(advanced as SetupJson);
             await verifyEnv(env);
         },
-        Timeouts.TEST
+        Timeouts.SETUP
     );
 });

--- a/test/common/index.ts
+++ b/test/common/index.ts
@@ -1,7 +1,7 @@
 export const Timeouts = {
-    SETUP: 5 * 60 * 1000, // 5 minutes
-    TEARDOWN: 1 * 60 * 1000, // 1 minute
-    TEST: 1 * 60 * 1000 // 1 minute
+    SETUP: 10 * 60 * 1000, // 5 minutes
+    TEARDOWN: 10 * 60 * 1000, // 1 minute
+    TEST: 5 * 60 * 1000 // 1 minute
 };
 
 export enum State {


### PR DESCRIPTION
This PR.
- Increases setup and teardown timeouts to 10 minutes
- Increases test timeout to 5 minutes
- Increases healthcheck timeout to 2 minutes
- Sets "setup timeout" as bootstrapping.test.ts timeout. (This test will be removed soon in another pr)